### PR TITLE
Wind

### DIFF
--- a/src/ShipMMG.jl
+++ b/src/ShipMMG.jl
@@ -13,6 +13,7 @@ export calc_position,
     ShipData,
     get_KVLCC2_L7_basic_params,
     get_KVLCC2_L7_maneuvering_params,
+    get_structure_params,
     get_KVLCC2_L7_params,
     nuts_sampling_single_thread,
     nuts_sampling_multi_threads
@@ -28,12 +29,14 @@ export kt_simulate,
 include("mmg.jl")
 export Mmg3DofBasicParams,
     Mmg3DofManeuveringParams,
+    Mmg3DofStructureParams,
     mmg_3dof_simulate,
     mmg_3dof_model!,
     mmg_3dof_zigzag_test,
     estimate_mmg_approx_lsm,
     estimate_mmg_approx_lsm_time_window_sampling,
-    create_model_for_mcmc_sample_mmg
+    create_model_for_mcmc_sample_mmg,
+    wind_force_and_moment_coefficients
 
 include("draw.jl")
 export draw_gif_result, calc_position

--- a/src/data.jl
+++ b/src/data.jl
@@ -1,4 +1,4 @@
-@with_kw struct ShipData{Tt,Tu,Tv,Tr,Tx,Ty,Tψ,Tδ,Tn_p}
+@with_kw struct ShipData{Tt,Tu,Tv,Tr,Tx,Ty,Tψ,Tδ,Tn_p,Tu_wind,Tψ_wind}
     time::Tt
     u::Tu
     v::Tv
@@ -8,6 +8,8 @@
     ψ::Tψ
     δ::Tδ
     n_p::Tn_p
+    u_wind::Tu_wind
+    ψ_wind::Tψ_wind
 end
 
 function get_KVLCC2_L7_basic_params(ρ = 1025.0)
@@ -136,6 +138,34 @@ function get_KVLCC2_L7_maneuvering_params()
         N_rrr_dash,
     )
     maneuvering_params
+end
+
+function get_structure_params()
+    L_pp = 7.00  # 船長Lpp[m]
+    B = 1.27  # 船幅[m]
+    d = 0.46  # 喫水[m]
+    D = 0.6563 # 深さ[m]
+    A_OD = 0.65 # デッキ上の構造物の側面投影面積[m^2]
+    H_BR = 0.85 # 喫水からブリッジ主要構造物の最高位[m]
+    H_C = 0.235 # 喫水から側面積中心までの高さ[m]
+    C = 0.0 # 船体中心から側面積中心までの前後方向座標(船首方向を正)[m]
+
+    A_OD = A_OD # デッキ上の構造物の側面投影面積[m^2]
+    A_F = (D - d) * B  # 船体の正面投影面積[m^2]
+    A_L = (D - d) * L_pp # 船体の側面投影面積[m^2]
+    H_BR = H_BR # 喫水からブリッジ主要構造物の最高位[m]
+    H_C = H_C # 喫水から側面積中心までの高さ[m]
+    C = C # 船体中心から側面積中心までの前後方向座標[m]
+    
+    structure_params = Mmg3DofStructureParams(
+        A_OD,
+        A_F,
+        A_L,
+        H_BR,
+        H_C,
+        C,
+    )
+    structure_params
 end
 
 function get_KVLCC2_L7_params()

--- a/src/mmg.jl
+++ b/src/mmg.jl
@@ -1,11 +1,102 @@
 """
+    wind_force_and_moment_coefficients(ψ,ψ_wind,p)
+
+conpute the parameter C_X,C_Y,C_N
+
+# Arguments
+-`ψ`:ship angle
+-`ψ_wind`:wind direction[deg]
+- L_pp
+- B
+- A_OD
+- A_F
+- A_L
+- H_BR
+- H_C
+- C
+"""
+
+function wind_force_and_moment_coefficients(
+    ψ,
+    ψ_wind,
+    L_pp,
+    B,
+    A_OD,
+    A_F,
+    A_L,
+    H_BR,
+    H_C,
+    C)
+
+
+    #ラジアンの調整
+    ψ %= 2pi
+
+    if ψ < 0
+        ψ += 2pi
+    end
+
+    #風の船体に対する流入角ψ_Aの計算
+    ψ_A = pi/2 + ψ - deg2rad(ψ_wind)
+
+    if ψ_A < 0
+        ψ_A += 2pi
+    elseif ψ_A > 2pi
+        ψ_A -= 2pi
+    end
+
+    #C_LF1の場合で調整
+    C_CF = 0.404 + 0.368 * A_F / (B * H_BR) + 0.902 * H_BR / L_pp
+
+    if deg2rad(0) <= ψ_A <= deg2rad(90) 
+
+        C_LF = -0.992 + 0.507 * A_L / (L_pp * B) + 1.162 * C / L_pp
+        C_XLI = 0.458 + 3.245 * A_L / (L_pp * H_BR) - 2.313 * A_F / (B * H_BR)
+        C_ALF = -0.585 - 0.906 * A_OD / A_L + 3.239 * B / L_pp
+        C_YLI = pi * A_L / L_pp^2 + 0.116 +3.345 * A_F / (L_pp * B)
+
+    elseif deg2rad(90) < ψ_A <= deg2rad(180)
+
+        C_LF = 0.018 - 5.091 * B / L_pp + 10.367 * H_C / L_pp -3.011 * A_OD / L_pp^2 - 0.341 * A_F / B^2 
+        C_XLI = -1.901 + 12.727 * A_L / (L_pp * H_BR) + 24.407 * A_F / A_L - 40.310 * B / L_pp - 0.341 * A_F / (B * H_BR)
+        C_ALF = -0.314 - 1.117 * A_OD / A_L
+        C_YLI = pi * A_L / L_pp^2 + 0.446 + 2.192 * A_F / L_pp ^2
+
+    elseif deg2rad(180) < ψ_A <= deg2rad(270)
+
+        C_LF = 0.018 - 5.091 * B / L_pp + 10.367 * H_C / L_pp -3.011 * A_OD / L_pp^2 - 0.341 * A_F / B^2 
+        C_XLI = -1.901 + 12.727 * A_L / (L_pp * H_BR) + 24.407 * A_F / A_L - 40.310 * B / L_pp - 0.341 * A_F / (B * H_BR)
+        C_ALF = -(-0.314 - 1.117 * A_OD / A_L)
+        C_YLI = -(pi * A_L / L_pp^2 + 0.446 + 2.192 * A_F / L_pp ^2)
+
+    elseif deg2rad(270) < ψ_A <= deg2rad(360)
+        
+        C_LF = -0.992 + 0.507 * A_L / (L_pp * B) + 1.162 * C / L_pp
+        C_XLI = 0.458 + 3.245 * A_L / (L_pp * H_BR) - 2.313 * A_F / (B * H_BR)
+        C_ALF = -(-0.585 - 0.906 * A_OD / A_L + 3.239 * B / L_pp)
+        C_YLI = -(pi * A_L / L_pp^2 + 0.116 +3.345 * A_F / (L_pp * B))
+
+    end
+
+
+    C_X = C_LF * cos(ψ_A) + C_XLI * (sin(ψ_A) - sin(ψ_A) * cos(ψ_A)^2 / 2) * sin(ψ_A) * cos(ψ_A) + C_ALF * sin(ψ_A) * cos(ψ_A)^3
+    C_Y = C_CF * sin(ψ_A)^2 + C_YLI * (cos(ψ_A) + sin(ψ_A)^2 * cos(ψ_A) / 2) * sin(ψ_A) * cos(ψ_A)
+    C_N = C_Y * (0.297 * C / L_pp - 0.149 * (ψ_A - deg2rad(90)))
+
+
+    C_X,C_Y,C_N
+
+end
+
+
+"""
     mmg_3dof_model!(dX, X, p, t)
 
 MMG 3DOF model on DifferentialEquations.ODEProblem. Update `dX`.
 
 # Arguments
-- `dX`: [du, dv, dr, dx, dy, dΨ, dδ, dn_p]
-- `X`: the initial state values. [`u`, `v`, `r`, `x`, `y`, `Ψ`, `δ`, `n_p`].
+- `dX`: [du, dv, dr, dx, dy, dψ, dδ, dn_p, du_wind, dψ_wind]
+- `X`: the initial state values. [`u`, `v`, `r`, `x`, `y`, `ψ`, `δ`, `n_p`,`u_wind`,`ψ_wind`].
 - `p`: ρ and the basic & maneuvering parameters and δ & n_p spline info.
     - ρ
     - L_pp
@@ -33,6 +124,12 @@ MMG 3DOF model on DifferentialEquations.ODEProblem. Update `dX`.
     - t_P
     - w_P0
     - x_P
+    - A_OD
+    - A_F
+    - A_L
+    - H_BR
+    - H_C
+    - C
     - k_0
     - k_1
     - k_2
@@ -55,10 +152,12 @@ MMG 3DOF model on DifferentialEquations.ODEProblem. Update `dX`.
     - N_rrr_dash
     - spl_δ
     - spl_n_p
+    - u_wind_list
+    - ψ_wind_list
 - `t`: the time.
 """
 function mmg_3dof_model!(dX, X, p, t)
-    u, v, r, x, y, Ψ, δ, n_p = X
+    u, v, r, x, y, ψ, δ, n_p, u_wind, ψ_wind = X
     ρ,
     L_pp,
     B,
@@ -85,6 +184,12 @@ function mmg_3dof_model!(dX, X, p, t)
     t_P,
     w_P0,
     x_P,
+    A_OD,
+    A_F,
+    A_L,
+    H_BR,
+    H_C,
+    C,
     k_0,
     k_1,
     k_2,
@@ -106,7 +211,9 @@ function mmg_3dof_model!(dX, X, p, t)
     N_vrr_dash,
     N_rrr_dash,
     spl_δ,
-    spl_n_p = p
+    spl_n_p,
+    spl_u_wind,
+    spl_ψ_wind = p
 
     U = sqrt(u^2 + (v - r * x_G)^2)
 
@@ -214,19 +321,43 @@ function mmg_3dof_model!(dX, X, p, t)
         )
     )
     N_R = -(x_R + a_H * x_H) * F_N * cos(δ)
-    dX[1] = du = ((X_H + X_R + X_P) + (m + m_y) * v * r + x_G * m * (r^2)) / (m + m_x)
+
+    
+
+    C_X_wind,C_Y_wind,C_N_wind = wind_force_and_moment_coefficients(
+        ψ,
+        ψ_wind,
+        L_pp,
+        B,
+        A_OD,
+        A_F,
+        A_L,
+        H_BR,
+        H_C,
+        C
+    )
+
+    ρ_air = 1.225
+    X_wind =  ρ_air * A_F * C_X_wind / 2 * u_wind^2
+    Y_wind = ρ_air * A_L * C_Y_wind / 2  * u_wind^2
+    N_wind = ρ_air * A_L * L_pp * C_N_wind / 2 * u_wind^2
+
+
+    dX[1] = du = ((X_H + X_R + X_P + X_wind ) + (m + m_y) * v * r + x_G * m * (r^2)) / (m + m_x)
     dX[2] =
         dv =
             (
-                (x_G^2) * (m^2) * u * r - (N_H + N_R) * x_G * m +
-                ((Y_H + Y_R) - (m + m_x) * u * r) * (I_zG + J_z + (x_G^2) * m)
+                (x_G^2) * (m^2) * u * r - (N_H + N_R + N_wind ) * x_G * m +
+                ((Y_H + Y_R + Y_wind ) - (m + m_x) * u * r) * (I_zG + J_z + (x_G^2) * m)
             ) / ((I_zG + J_z + (x_G^2) * m) * (m + m_y) - (x_G^2) * (m^2))
-    dX[3] = dr = (N_H + N_R - x_G * m * (dv + u * r)) / (I_zG + J_z + (x_G^2) * m)
-    dX[4] = dx = u * cos(Ψ) - v * sin(Ψ)
-    dX[5] = dy = u * sin(Ψ) + v * cos(Ψ)
-    dX[6] = dΨ = r
+    dX[3] = dr = (N_H + N_R + N_wind  - x_G * m * (dv + u * r)) / (I_zG + J_z + (x_G^2) * m)
+    dX[4] = dx = u * cos(ψ) - v * sin(ψ)
+    dX[5] = dy = u * sin(ψ) + v * cos(ψ)
+    dX[6] = dψ = r
     dX[7] = dδ = derivative(spl_δ, t)
     dX[8] = dn_p = derivative(spl_n_p, t)
+    dX[9] = du_wind = derivative(spl_u_wind, t)
+    dX[10] = dψ_wind = derivative(spl_ψ_wind, t)
 end
 
 """
@@ -336,23 +467,46 @@ Maneuvering parameters of target ship for MMG 3DOF simulation.
 end
 
 """
-    mmg_3dof_simulate(time_list, n_p_list, δ_list, basic_params, maneuvering_params, [, u0, v0, r0, x0, y0, Ψ0, ρ, algorithm, reltol, abstol]) -> u, v, r, x, y, Ψ, δ, n_p
+Sturucture parameters of target ship for MMG 3DOF simulation.
 
-Returns the MMG 3DOF simulation results including the lists of time, u, v, r, x, y, Ψ, δ, n_p.
+# Arguments
+- `A_OD::T`
+- `A_F::T`
+- `A_L::T`
+- `H_BR::T`
+- `H_C::T`
+- `C::T`
+"""
+@with_kw mutable struct Mmg3DofStructureParams{T}
+    A_OD::T
+    A_F::T
+    A_L::T
+    H_BR::T
+    H_C::T
+    C::T
+end
+
+"""
+    mmg_3dof_simulate(time_list, n_p_list, δ_list, u_wind_list, ψ_wind_list basic_params, maneuvering_params,structure_params, [ u0, v0, r0, x0, y0, ψ0, ρ, algorithm, reltol, abstol]) -> u, v, r, x, y, ψ, δ, n_p
+
+Returns the MMG 3DOF simulation results including the lists of time, u, v, r, x, y, ψ, δ, n_p.
 This function has the same logic of `ShipMMG.simulate()`.
 
 # Arguments
 - `basic_params::Mmg3DofBasicParams`: the basic parameters of target ship.
 - `maneuvering_params::Mmg3DofManeuveringParams`: the maneuvering parameters of target ship.
+- `structure_params::Mmg3DofStructureParams,` : the Structur parameters above the  taeget ship's draft
 - `time_list`: the list of simulatino time.
 - `δ_list`: the list of rudder angle [rad].
 - `n_p_list`: the list of propeller rps.
+- `u_wind_list` :the list of wind velocity [m/s].
+- `ψ_wind_list` :the list of wind direction [deg].
 - `u0=0.0`: the initial x (surge) velocity.
 - `v0=0.0`: the initial y (sway) velocity.
 - `r0=0.0`: the initial rate of turn [rad/s].
 - `x0=0.0`: the initial x (surge) position.
 - `y0=0.0`: the initial y (sway) position.
-- `Ψ0=0.0`: the initial Ψ (yaw) azimuth [rad].
+- `ψ0=0.0`: the initial ψ (yaw) azimuth [rad].
 - `ρ=1025.0`: the seawater density [kg/m^3].
 - `algorithm=Tsit5()`: the parameter of DifferentialEquations.ODEProblem.solve()
 - `reltol=1e-8`: the parameter of DifferentialEquations.ODEProblem.solve()
@@ -370,12 +524,16 @@ julia> sampling = duration * 10;
 julia> time_list = range(0.00, stop = duration, length = sampling);
 julia> δ_rad_list = max_δ_rad .* ones(Float64, sampling);
 julia> n_p_list = n_const .* ones(Float64, sampling);
+julia> u_wind_list = max_δ_rad .* ones(Float64, sampling);
+julia> ψ_wind_list = n_const .* ones(Float64, sampling);
 julia> mmg_results = mmg_3dof_simulate(
     basic_params,
     maneuvering_params,
     time_list,
     δ_rad_list,
     n_p_list,
+    u_wind_list,
+    ψ_wind_list,
     u0 = 2.29 * 0.512,
     v0 = 0.0,
     r0 = 0.0,
@@ -385,15 +543,18 @@ julia> mmg_results = mmg_3dof_simulate(
 function mmg_3dof_simulate(
     basic_params::Mmg3DofBasicParams,
     maneuvering_params::Mmg3DofManeuveringParams,
+    structure_params::Mmg3DofStructureParams,
     time_list,
     δ_list,
-    n_p_list;
+    n_p_list,
+    u_wind_list,
+    ψ_wind_list;
     u0=0.0,
     v0=0.0,
     r0=0.0,
     x0=0.0,
     y0=0.0,
-    Ψ0=0.0,
+    ψ0=0.0,
     ρ=1025.0,
     algorithm=Tsit5(),
     reltol=1e-8,
@@ -445,6 +606,14 @@ function mmg_3dof_simulate(
     N_vvr_dash,
     N_vrr_dash,
     N_rrr_dash = maneuvering_params
+
+    @unpack A_OD,
+    A_F,
+    A_L,
+    H_BR,
+    H_C,
+    C = structure_params
+
     simulate(
         L_pp,
         B,
@@ -471,6 +640,12 @@ function mmg_3dof_simulate(
         t_P,
         w_P0,
         x_P,
+        A_OD,
+        A_F,
+        A_L,
+        H_BR,
+        H_C,
+        C,
         k_0,
         k_1,
         k_2,
@@ -494,12 +669,14 @@ function mmg_3dof_simulate(
         time_list,
         δ_list,
         n_p_list,
+        u_wind_list,
+        ψ_wind_list,
         u0=u0,
         v0=v0,
         r0=r0,
         x0=x0,
         y0=y0,
-        Ψ0=Ψ0,
+        ψ0=ψ0,
         ρ=ρ,
         algorithm=algorithm,
         reltol=reltol,
@@ -508,9 +685,9 @@ function mmg_3dof_simulate(
 end
 
 """
-    simulate(time_list, n_p_list, δ_list, L_pp, B, d, x_G, D_p, m, I_zG, A_R, η, m_x, m_y, J_z, f_α, ϵ, t_R, x_R, a_H, x_H, γ_R_minus, γ_R_plus, l_R, κ, t_P, w_P0, x_P, k_0, k_1, k_2, R_0_dash, X_vv_dash, X_vr_dash, X_rr_dash, X_vvvv_dash, Y_v_dash, Y_r_dash, Y_vvv_dash, Y_vvr_dash, Y_vrr_dash, Y_rrr_dash, N_v_dash, N_r_dash, N_vvv_dash, N_vvr_dash, N_vrr_dash, N_rrr_dash, [, u0, v0, r0, ρ, algorithm, reltol, abstol]) -> u, v, r, x, y, Ψ, δ, n_p
+    simulate(time_list, n_p_list, δ_list, u_wind_list, ψ_wind_list, L_pp, B, d, x_G, D_p, m, I_zG, A_R, η, m_x, m_y, J_z, f_α, ϵ, t_R, x_R, a_H, x_H, γ_R_minus, γ_R_plus, l_R, κ, t_P, w_P0, x_P, A_OD, A_F, A_L, H_BR, H_C, C, k_0, k_1, k_2, R_0_dash, X_vv_dash, X_vr_dash, X_rr_dash, X_vvvv_dash, Y_v_dash, Y_r_dash, Y_vvv_dash, Y_vvr_dash, Y_vrr_dash, Y_rrr_dash, N_v_dash, N_r_dash, N_vvv_dash, N_vvr_dash, N_vrr_dash, N_rrr_dash, [, u0, v0, r0, ρ, algorithm, reltol, abstol]) -> u, v, r, x, y, ψ, δ, n_p
 
-Returns the MMG 3DOF simulation results including the lists of time, u, v, r, x, y, Ψ, δ, n_p.
+Returns the MMG 3DOF simulation results including the lists of time, u, v, r, x, y, ψ, δ, n_p.
 This function has the same logic of `ShipMMG.mmg_3dof_simulate()`.
 
 # Arguments
@@ -539,6 +716,12 @@ This function has the same logic of `ShipMMG.mmg_3dof_simulate()`.
 - `t_P`: 
 - `w_P0`: 
 - `x_P`: 
+- `A_OD:`
+- `A_F:`
+- `A_L:`
+- `H_BR:`
+- `H_C:`
+- `C:`
 - `k_0`
 - `k_1`
 - `k_2`
@@ -562,12 +745,14 @@ This function has the same logic of `ShipMMG.mmg_3dof_simulate()`.
 - `time_list`: the list of simulatino time.
 - `δ_list`: the list of rudder angle [rad].
 - `n_p_list`: the list of propeller rps.
+- `u_wind_list` :the list of wind velocity [m/s].
+- `ψ_wind_list` :the list of wind direction [deg].
 - `u0=0.0`: the initial x (surge) velocity.
 - `v0=0.0`: the initial y (sway) velocity.
 - `r0=0.0`: the initial rate of turn [rad/s].
 - `x0=0.0`: the initial x (surge) position.
 - `y0=0.0`: the initial y (sway) position.
-- `Ψ0=0.0`: the initial Ψ (yaw) azimuth [rad].
+- `ψ0=0.0`: the initial ψ (yaw) azimuth [rad].
 - `ρ=1025.0`: the seawater density [kg/m^3].
 - `algorithm=Tsit5()`: the parameter of DifferentialEquations.ODEProblem.solve()
 - `reltol=1e-8`: the parameter of DifferentialEquations.ODEProblem.solve()
@@ -599,6 +784,12 @@ function simulate(
     t_P,
     w_P0,
     x_P,
+    A_OD,
+    A_F,
+    A_L,
+    H_BR,
+    H_C,
+    C,
     k_0,
     k_1,
     k_2,
@@ -621,13 +812,15 @@ function simulate(
     N_rrr_dash,
     time_list,
     δ_list,
-    n_p_list;
+    n_p_list,
+    u_wind_list,
+    ψ_wind_list;
     u0=0.0,
     v0=0.0,
     r0=0.0,
     x0=0.0,
     y0=0.0,
-    Ψ0=0.0,
+    ψ0=0.0,
     ρ=1025.0,
     algorithm=Tsit5(),
     reltol=1e-8,
@@ -635,8 +828,12 @@ function simulate(
 )
     spl_δ = Spline1D(time_list, δ_list)
     spl_n_p = Spline1D(time_list, n_p_list)
+    
+    spl_u_wind = Spline1D(time_list, u_wind_list)
+    spl_ψ_wind = Spline1D(time_list, ψ_wind_list)
 
-    X0 = [u0; v0; r0; x0; y0; Ψ0; δ_list[1]; n_p_list[1]]
+
+    X0 = [u0; v0; r0; x0; y0; ψ0; δ_list[1]; n_p_list[1]; u_wind_list[1]; ψ_wind_list[1]]
     p = [
         ρ,
         L_pp,
@@ -664,6 +861,12 @@ function simulate(
         t_P,
         w_P0,
         x_P,
+        A_OD,
+        A_F,
+        A_L,
+        H_BR,
+        H_C,
+        C,
         k_0,
         k_1,
         k_2,
@@ -686,6 +889,8 @@ function simulate(
         N_rrr_dash,
         spl_δ,
         spl_n_p,
+        spl_u_wind,
+        spl_ψ_wind,
     ]
     prob = ODEProblem(mmg_3dof_model!, X0, (time_list[1], time_list[end]), p)
     sol = solve(prob, algorithm, reltol=reltol, abstol=abstol)
@@ -696,30 +901,34 @@ function simulate(
     r = results[3, :]
     x = results[4, :]
     y = results[5, :]
-    Ψ = results[6, :]
+    ψ = results[6, :]
     δ = results[7, :]
     n_p = results[8, :]
-    u, v, r, x, y, Ψ, δ, n_p
+    u_wind = results[9, :]
+    ψ_wind = results[10, :]
+    u, v, r, x, y, ψ, δ, n_p, u_wind, ψ_wind
 end
 
 """
-    mmg_3dof_zigzag_test(basic_params, maneuvering_params, time_list, n_p_list, target_δ_rad, target_Ψ_rad_deviation, [, u0, v0, r0, x0, y0, Ψ0, δ0, δ_rad_rate, algorithm, reltol, abstol]) -> u, v, r, x, y, Ψ, δ
+    mmg_3dof_zigzag_test(basic_params, maneuvering_params,structure_params time_list, n_p_list, u_wind_list, Ψ_wind_list, target_δ_rad, target_Ψ_rad_deviation, [, u0, v0, r0, x0, y0, Ψ0, δ0, δ_rad_rate, algorithm, reltol, abstol]) -> u, v, r, x, y, ψ, δ
 
 Returns the MMG 3DOF zigzag simulation results.
 
 # Arguments
 - `basic_params::Mmg3DofBasicParams`: the basic parameters of target ship.
 - `maneuvering_params::Mmg3DofManeuveringParams`: the maneuvering parameters of target ship.
+- `structure_params::Mmg3DofStructureParams,` : the Structur parameters above the  taeget ship's draft
 - `time_list`: the list of simulatino time.
+- `δ_list`: the list of rudder angle [rad].
 - `n_p_list`: the list of propeller rps.
-- `target_δ_rad`: target rudder angle of zigzag test.
-- `target_Ψ_rad_deviation`: target azimuth deviation of zigzag test.
+- `u_wind_list` :the list of wind velocity [m/s].
+- `ψ_wind_list` :the list of wind direction [deg].
 - `u0=0.0`: the initial x (surge) velocity.
 - `v0=0.0`: the initial y (sway) velocity.
 - `r0=0.0`: the initial rate of turn [rad/s].
 - `x0=0.0`: the initial x (surge) position.
 - `y0=0.0`: the initial y (sway) position.
-- `Ψ0=0.0`: the initial Ψ (yaw) azimuth [rad].
+- `ψ0=0.0`: the initial ψ (yaw) azimuth [rad].
 - `δ0=0.0`: the initial rudder angle.
 - `δ_rad_rate=10.0*π/180`: the change rate of rudder angle [rad/s]. 
 - `ρ=1025.0`: the seawater density [kg/m^3].
@@ -734,36 +943,43 @@ KVLCC2_L7 zigzag test.
 julia> ρ = 1025.0;
 julia> basic_params, maneuvering_params = get_KVLCC2_L7_params();
 julia> target_δ_rad = 20.0 * π / 180.0
-julia> target_Ψ_rad_deviation = 20.0 * π / 180.0
+julia> target_ψ_rad_deviation = 20.0 * π / 180.0
 julia> start_time_second = 0.00
 julia> time_second_interval = 0.01
 julia> end_time_second = 80.00
 julia> time_list = start_time_second:time_second_interval:end_time_second
 julia> n_const = 17.95  # [rps]
 julia> n_p_list = n_const * ones(Float64, length(time_list))
-julia> δ_list, u_list, v_list, r_list, Ψ_list = mmg_3dof_zigzag_test(
+julia> u_wind_list = max_δ_rad .* ones(Float64, sampling);
+julia> ψ_wind_list = n_const .* ones(Float64, sampling);
+julia> δ_list, u_list, v_list, r_list, ψ_list = mmg_3dof_zigzag_test(
     basic_params,
     maneuvering_params,
     time_list
     n_p_list,
+    u_wind_list,
+    ψ_wind_list,
     target_δ_rad,
-    target_Ψ_rad_deviation,
+    target_ψ_rad_deviation,
 );
 ```
 """
 function mmg_3dof_zigzag_test(
     basic_params::Mmg3DofBasicParams,
     maneuvering_params::Mmg3DofManeuveringParams,
+    structure_params::Mmg3DofStructureParams,
     time_list,
     n_p_list,
     target_δ_rad,
-    target_Ψ_rad_deviation;
+    target_ψ_rad_deviation,
+    u_wind_list,
+    ψ_wind_list;
     u0=0.0,
     v0=0.0,
     r0=0.0,
     x0=0.0,
     y0=0.0,
-    Ψ0=0.0,
+    ψ0=0.0,
     δ0=0.0,
     δ_rad_rate=10.0 * π / 180,
     ρ=1025.0,
@@ -771,7 +987,7 @@ function mmg_3dof_zigzag_test(
     reltol=1e-8,
     abstol=1e-8
 )
-    target_Ψ_rad_deviation = abs(target_Ψ_rad_deviation)
+    target_ψ_rad_deviation = abs(target_ψ_rad_deviation)
 
     final_δ_list = zeros(length(time_list))
     final_u_list = zeros(length(time_list))
@@ -779,11 +995,11 @@ function mmg_3dof_zigzag_test(
     final_r_list = zeros(length(time_list))
     final_x_list = zeros(length(time_list))
     final_y_list = zeros(length(time_list))
-    final_Ψ_list = zeros(length(time_list))
+    final_ψ_list = zeros(length(time_list))
 
     next_stage_index = 1
     target_δ_rad = -target_δ_rad  # for changing in while loop
-    Ψ = Ψ0
+    ψ = ψ0
     while next_stage_index < length(time_list)
         target_δ_rad = -target_δ_rad
         start_index = next_stage_index
@@ -823,18 +1039,21 @@ function mmg_3dof_zigzag_test(
             end
         end
 
-        u, v, r, x, y, Ψ_list, δ, n_p = mmg_3dof_simulate(
+        u, v, r, x, y, ψ_list, δ, n_p = mmg_3dof_simulate(
             basic_params,
             maneuvering_params,
+            structure_params,
             time_list[start_index:end],
             δ_list,
             n_p_list[start_index:end],
+            u_wind_list[start_index:end],
+            ψ_wind_list[start_index:end];
             u0=u0,
             v0=v0,
             r0=r0,
             x0=x0,
             y0=y0,
-            Ψ0=Ψ,
+            ψ0=ψ,
             ρ=ρ,
             algorithm=algorithm,
             reltol=reltol,
@@ -842,13 +1061,13 @@ function mmg_3dof_zigzag_test(
         )
 
         # get finish index
-        target_Ψ_rad = Ψ0 + target_Ψ_rad_deviation
+        target_ψ_rad = ψ0 + target_ψ_rad_deviation
         if target_δ_rad < 0
-            target_Ψ_rad = Ψ0 - target_Ψ_rad_deviation
+            target_ψ_rad = ψ0 - target_ψ_rad_deviation
         end
-        over_index = findfirst(e -> e > target_Ψ_rad, Ψ_list)
+        over_index = findfirst(e -> e > target_ψ_rad, ψ_list)
         if target_δ_rad < 0
-            over_index = findfirst(e -> e < target_Ψ_rad, Ψ_list)
+            over_index = findfirst(e -> e < target_ψ_rad, ψ_list)
         end
         next_stage_index = length(time_list)
         if isnothing(over_index)
@@ -858,9 +1077,9 @@ function mmg_3dof_zigzag_test(
             final_r_list[start_index:next_stage_index] = r
             final_x_list[start_index:next_stage_index] = x
             final_y_list[start_index:next_stage_index] = y
-            final_Ψ_list[start_index:next_stage_index] = Ψ_list
+            final_ψ_list[start_index:next_stage_index] = ψ_list
         else
-            Ψ = Ψ_list[over_index]
+            ψ = ψ_list[over_index]
             next_stage_index = over_index + start_index - 1
             final_δ_list[start_index:next_stage_index-1] = δ_list[begin:over_index-1]
             final_u_list[start_index:next_stage_index-1] = u[begin:over_index-1]
@@ -868,7 +1087,7 @@ function mmg_3dof_zigzag_test(
             final_r_list[start_index:next_stage_index-1] = r[begin:over_index-1]
             final_x_list[start_index:next_stage_index-1] = x[begin:over_index-1]
             final_y_list[start_index:next_stage_index-1] = y[begin:over_index-1]
-            final_Ψ_list[start_index:next_stage_index-1] = Ψ_list[begin:over_index-1]
+            final_ψ_list[start_index:next_stage_index-1] = ψ_list[begin:over_index-1]
         end
     end
     final_u_list,
@@ -876,7 +1095,7 @@ function mmg_3dof_zigzag_test(
     final_r_list,
     final_x_list,
     final_y_list,
-    final_Ψ_list,
+    final_ψ_list,
     final_δ_list
 end
 
@@ -915,6 +1134,7 @@ function create_model_for_mcmc_sample_mmg(
     u_obs = data.u
     v_obs = data.v
     r_obs = data.r
+    ψ_obs = data.ψ
     δ_obs = data.δ
     n_p_obs = data.n_p
 
@@ -948,7 +1168,7 @@ function create_model_for_mcmc_sample_mmg(
     spl_δ = Spline1D(time_obs, δ_obs)
     spl_n_p = Spline1D(time_obs, n_p_obs)
     function MMG!(dX, X, p, t)
-        u, v, r, δ, n_p = X
+        u, v, r, ψ, δ, n_p = X
         R_0_dash,
         X_vv_dash,
         X_vr_dash,
@@ -1073,9 +1293,11 @@ function create_model_for_mcmc_sample_mmg(
             )
         )
         N_R = -(x_R + a_H * x_H) * F_N * cos(δ)
+
+        ρ_air = 1.225
+
         dX[1] = du = ((X_H + X_R + X_P) + (m + m_y) * v * r + x_G * m * (r^2)) / (m + m_x)
-        dX[2] =
-            dv =
+        dX[2] = dv =
                 (
                     (x_G^2) * (m^2) * u * r - (N_H + N_R) * x_G * m +
                     ((Y_H + Y_R) - (m + m_x) * u * r) * (I_zG + J_z + (x_G^2) * m)
@@ -1126,7 +1348,7 @@ function create_model_for_mcmc_sample_mmg(
     u0 = 2.29 * 0.512
     v0 = 0.0
     r0 = 0.0
-    X0 = [u_obs[1]; v_obs[1]; r_obs[1]; δ_obs[1]; n_p_obs[1]]
+    X0 = [u_obs[1]; v_obs[1]; r_obs[1]; ψ_obs[1]; δ_obs[1]; n_p_obs[1];]
     prob1 = ODEProblem(MMG!, X0, (time_obs[1], time_obs[end]), p)
 
     # create probabilistic model
@@ -1174,7 +1396,7 @@ function create_model_for_mcmc_sample_mmg(
         prob = remake(prob1, p=p)
         sol = solve(prob, solver, abstol=abstol, reltol=reltol)
         predicted = sol(time_obs)
-        for i = 1:length(predicted)
+        for i in eachindex(predicted)
             obs[1][i] ~ Normal(predicted[i][1], σ_u) # u
             obs[2][i] ~ Normal(predicted[i][2], σ_v) # v
             obs[3][i] ~ Normal(predicted[i][3], σ_r) # r

--- a/test/test_mmg.jl
+++ b/test/test_mmg.jl
@@ -10,12 +10,17 @@ basic_params, maneuvering_params = get_KVLCC2_L7_params()
     time_list = range(0.00, stop=duration, length=sampling)
     δ_rad_list = max_δ_rad .* ones(Float64, sampling)
     n_p_list = n_const .* ones(Float64, sampling)
+    u_wind_list = rand(Normal(8,1),length(time_list))
+    ψ_wind_list = rand(Normal(0,0.1)length(time_list))
+
     mmg_results = mmg_3dof_simulate(
         basic_params,
         maneuvering_params,
         time_list,
         δ_rad_list,
         n_p_list,
+        u_wind_list,
+        ψ_wind_list,
         u0=2.29 * 0.512,
         v0=0.0,
         r0=0.0,
@@ -33,6 +38,8 @@ end
     time_list = start_time_second:time_second_interval:end_time_second
     n_const = 17.95  # [rps]
     n_p_list = n_const * ones(Float64, length(time_list))
+    u_wind_list = rand(Normal(8,1),length(time_list))
+    ψ_wind_list = rand(Normal(0,0.1)length(time_list))
     u_list, v_list, r_list, x_list, y_list, ψ_list, δ_list = mmg_3dof_zigzag_test(
         basic_params,
         maneuvering_params,
@@ -40,6 +47,8 @@ end
         n_p_list,
         target_δ_rad,
         target_ψ_rad_deviation,
+        u_wind_list,
+        ψ_wind_list,
     )
 end
 


### PR DESCRIPTION
MMG model is changed to take wind force into account. 


**data.jl**
- Added functions for ship superstructure data `get_structure_params`

**mmg.jl**
- Added `wind_force_and_moment_ coefficients` to calculate wind force and moments coefficients based on Fujiwara's formula (https://www.jstage.jst.go.jp/article/jjasnaoe/2/0/2_0_243/_article/-char/ja/). 
- Add time-series data of wind speed and direction `u_wind_list`,`ψ_wind_list` to the arguments of existing functions.

**ShipMMG.jl**
- Changed due to changes in **data.jl**,**mmg.jl**

**test_mmg.jl**
-  Changed due to the changes in **data.jl**,**mmg.jl**,**ShipMMG.jl**

**Other changes**
- Change Psi from uppercase to lowercase (Ψ→ψ)
